### PR TITLE
Use env var for API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # gakusyoku
 gakusyoku
+
+## Environment Variables
+
+Create a `.env` file inside `my-react-app` with the following variable:
+
+```
+VITE_API_BASE_URL=https://gakusyokubackend.onrender.com
+```
+
+This value is used by the frontend to call the backend API.

--- a/my-react-app/.env
+++ b/my-react-app/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://gakusyokubackend.onrender.com

--- a/my-react-app/README.md
+++ b/my-react-app/README.md
@@ -2,6 +2,16 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Environment Variables
+
+Create a `.env` file in this directory and set the base URL for the backend API:
+
+```
+VITE_API_BASE_URL=https://gakusyokubackend.onrender.com
+```
+
+The application reads this value when requesting recommendations.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/my-react-app/src/components/Recommendations.jsx
+++ b/my-react-app/src/components/Recommendations.jsx
@@ -22,9 +22,11 @@ const Recommendations = ({
     const perMealBudget = Math.floor(finalBudget / mealCount);
     const results = [];
 
+    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
     for (let i = 0; i < mealCount; i++) {
       const res = await fetch(
-        `https://gakusyokubackend.onrender.com/recommend/${perMealBudget}`
+        `${baseUrl}/recommend/${perMealBudget}`
       );
       const data = await res.json();
       results.push({ mealIndex: i + 1, data });


### PR DESCRIPTION
## Summary
- add `.env` with `VITE_API_BASE_URL`
- document `VITE_API_BASE_URL` in READMEs
- read API base URL from `import.meta.env` in `Recommendations`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843c069302483298c3b62435a035ee0