### PR TITLE
Add custom budget input field

### DIFF
--- a/my-react-app/src/components/BudgetSelector.jsx
+++ b/my-react-app/src/components/BudgetSelector.jsx
@@ -43,6 +43,19 @@ const BudgetSelector = ({
         </button>
       </div>
 
+      {/* 任意の金額入力 */}
+      <div className="input-group">
+        <input
+          type="number"
+          placeholder="任意の金額"
+          value={customBudget}
+          onChange={(e) => {
+            setCustomBudget(e.target.value);
+            setSelectedBudget("");
+          }}
+        />
+      </div>
+
       <div className="section-title">食数選択</div>
       <div className="button-group">
         {[1, 2, 3].map((count) => (


### PR DESCRIPTION
## Summary
- allow users to enter custom budget amounts
- bind text field to `customBudget` state
- deselect preset budget buttons when typing custom value

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843c067c3d88329bc9e5a030c45f6a4