### PR TITLE
Handle missing API URL in Recommendations

### DIFF
--- a/my-react-app/src/components/Recommendations.jsx
+++ b/my-react-app/src/components/Recommendations.jsx
@@ -10,7 +10,14 @@ const Recommendations = ({
   const [loading, setLoading] = useState(false); // ← ローディング状態を管理
 
   // APIからおすすめ提案を取得する処理
+  const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
   const fetchRecommendations = async () => {
+    if (!baseUrl) {
+      alert("API URL not configured");
+      return;
+    }
+
     const budget = customBudget || selectedBudget;
     const finalBudget = parseInt(budget);
     if (!finalBudget || isNaN(finalBudget)) {
@@ -20,7 +27,6 @@ const Recommendations = ({
 
     setLoading(true); // ← 読み込み開始
     const perMealBudget = Math.floor(finalBudget / mealCount);
-    const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
     try {
       const results = await Promise.all(
@@ -49,7 +55,7 @@ const Recommendations = ({
 
   return (
     <div className="recommendations">
-      <button onClick={fetchRecommendations} disabled={loading}>
+      <button onClick={fetchRecommendations} disabled={loading || !baseUrl}>
         {loading ? "読み込み中..." : "提案を見る"}
       </button>
       {setCount > 0 && (


### PR DESCRIPTION
## Summary
- alert if API base URL is missing
- disable the fetch button when URL isn't set

## Testing
- `npm install`
- `npm run lint` *(fails: React prop-types and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_6843e16413948329b3fb76eb8d2d9f57