### PR TITLE
Add prop-types and cleanup React imports

### DIFF
--- a/my-react-app/package-lock.json
+++ b/my-react-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-react-app",
       "version": "0.0.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -3022,8 +3023,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3141,7 +3141,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3219,7 +3218,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3471,7 +3469,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3509,8 +3506,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/my-react-app/package.json
+++ b/my-react-app/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import "./App.css";
 import Header from "./components/Header";
 import BudgetSelector from "./components/BudgetSelector";
@@ -36,5 +36,7 @@ function App() {
     </>
   );
 }
+
+App.propTypes = {};
 
 export default App;

--- a/my-react-app/src/components/BudgetSelector.jsx
+++ b/my-react-app/src/components/BudgetSelector.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import PropTypes from "prop-types";
 
 const BudgetSelector = ({
   selectedBudget,
@@ -76,6 +76,15 @@ const BudgetSelector = ({
       </div>
     </div>
   );
+};
+
+BudgetSelector.propTypes = {
+  selectedBudget: PropTypes.string.isRequired,
+  customBudget: PropTypes.string.isRequired,
+  mealCount: PropTypes.number.isRequired,
+  setSelectedBudget: PropTypes.func.isRequired,
+  setCustomBudget: PropTypes.func.isRequired,
+  setMealCount: PropTypes.func.isRequired,
 };
 
 export default BudgetSelector;

--- a/my-react-app/src/components/Header.jsx
+++ b/my-react-app/src/components/Header.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 //import "./Header.css"; // 必要なら個別CSSも作成可能
 
 const Header = () => {
@@ -13,5 +12,7 @@ const Header = () => {
     </header>
   );
 };
+
+Header.propTypes = {};
 
 export default Header;

--- a/my-react-app/src/components/Recommendations.jsx
+++ b/my-react-app/src/components/Recommendations.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import PropTypes from "prop-types";
 
 const Recommendations = ({
   selectedBudget,
@@ -80,6 +81,14 @@ const Recommendations = ({
       )}
     </div>
   );
+};
+
+Recommendations.propTypes = {
+  selectedBudget: PropTypes.string.isRequired,
+  customBudget: PropTypes.string.isRequired,
+  mealCount: PropTypes.number.isRequired,
+  recommendations: PropTypes.array.isRequired,
+  setRecommendations: PropTypes.func.isRequired,
 };
 
 export default Recommendations;


### PR DESCRIPTION
## Summary
- install `prop-types`
- drop unused React imports
- define prop type expectations for components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843e16064f883299809d8c3c3dedd2e