### PR TITLE
Add environment template and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The backend API can be found at [gakusyoku-backend](https://github.com/matuhiro9
 
 ## Environment Variables
 
-Create a `.env` file inside `my-react-app` with the following variable:
+Copy `.env.example` inside `my-react-app` to `.env` and set the backend API URL:
 
 ```
 
@@ -14,7 +14,7 @@ VITE_API_BASE_URL=https://gakusyokubackend.onrender.com
 
 ```
 
-This value is used by the frontend to call the backend API.
+Replace the value with the actual base URL of your API. This value is used by the frontend to call the backend API.
 
 ## Setup
 

--- a/my-react-app/.env.example
+++ b/my-react-app/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and set the backend API base URL
+VITE_API_BASE_URL=

--- a/my-react-app/.gitignore
+++ b/my-react-app/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/my-react-app/README.md
+++ b/my-react-app/README.md
@@ -4,13 +4,13 @@ This template provides a minimal setup to get React working in Vite with HMR and
 
 ## Environment Variables
 
-Create a `.env` file in this directory and set the base URL for the backend API:
+Copy `.env.example` to `.env` in this directory and set the base URL for the backend API:
 
 ```
 VITE_API_BASE_URL=https://gakusyokubackend.onrender.com
 ```
 
-The application reads this value when requesting recommendations.
+Replace the value with the actual base URL of your API. The application reads this value when requesting recommendations.
 
 Currently, two official plugins are available:
 


### PR DESCRIPTION
## Summary
- ignore `.env` in React app
- provide `.env.example` with API URL placeholder
- instruct devs to copy `.env.example` to `.env` in docs

## Testing
- `npm install` *(fails: none)*
- `npm run lint` *(fails: many lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843e162aa8883299d25164d0aa51783