### PR TITLE
Add gitignore and improve build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Node modules
+my-react-app/node_modules/
+# Build output
+dist/
+my-react-app/dist/
+# Environment variables
+my-react-app/.env
+# Logs
+npm-debug.log*
+

--- a/my-react-app/eslint.config.js
+++ b/my-react-app/eslint.config.js
@@ -10,7 +10,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.node, ...globals.jest },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/my-react-app/package.json
+++ b/my-react-app/package.json
@@ -40,6 +40,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "gh-pages": "^6.0.0",
     "vite": "^6.1.0"
   }
 }

--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -37,6 +37,4 @@ function App() {
   );
 }
 
-App.propTypes = {};
-
 export default App;

--- a/my-react-app/src/components/Header.jsx
+++ b/my-react-app/src/components/Header.jsx
@@ -13,6 +13,4 @@ const Header = () => {
   );
 };
 
-Header.propTypes = {};
-
 export default Header;

--- a/my-react-app/src/components/Recommendations.jsx
+++ b/my-react-app/src/components/Recommendations.jsx
@@ -36,6 +36,9 @@ const Recommendations = ({
       const results = await Promise.all(
         [...Array(mealCount)].map(async (_, i) => {
           const res = await fetch(`${baseUrl}/recommend/${perMealBudget}`);
+          if (!res.ok) {
+            throw new Error('Server responded with ' + res.status);
+          }
           const data = await res.json();
           return { mealIndex: i + 1, data };
         })

--- a/my-react-app/src/components/__tests__/Recommendations.test.jsx
+++ b/my-react-app/src/components/__tests__/Recommendations.test.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import Recommendations from '../Recommendations';
 
 function renderComponent(props) {
@@ -48,12 +47,16 @@ describe('Recommendations', () => {
       () =>
         new Promise((resolve) => {
           resolveFetch = () =>
-            resolve({ json: () => Promise.resolve([]) });
+            resolve({ ok: true, json: () => Promise.resolve([]) });
         })
     );
     renderComponent();
-    fireEvent.click(screen.getByRole('button', { name: '提案を見る' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '提案を見る' }));
+    });
     expect(await screen.findByText('読み込み中...')).toBeInTheDocument();
-    resolveFetch();
+    await act(async () => {
+      resolveFetch();
+    });
   });
 });

--- a/my-react-app/vite.config.js
+++ b/my-react-app/vite.config.js
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: './',
+  base: '/gakusyoku/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- ignore Node.js build artifacts
- allow ESLint to recognize Jest and Node globals
- add `gh-pages` for deploy script
- set correct base path for GitHub Pages
- handle failed fetch responses
- clean up unused PropTypes
- update unit tests to avoid React warnings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68453ac864208329a7ea07ba28a364e6